### PR TITLE
add ci test

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,8 +33,19 @@ jobs:
           java-version: 1.8
       - name: lint
         run: ./gradlew spotlessCheck
-      - name: Test
-        run: ./gradlew test
+      - name: Write test secret to file
+        run: envsubst < ci/config_template.yml > test-config.yml
+        env:
+          SERVER_HOSTNAME: ${{ secrets.TEST_SERVER_HOSTNAME }}
+          HTTP_PATH: ${{ secrets.TEST_HTTP_PATH }}
+          PERSONAL_ACCESS_TOKEN: ${{ secrets.TEST_PERSONAL_ACCESS_TOKEN }}
+          CATALOG_NAME: ${{ secrets.TEST_CATALOG_NAME }}
+          SCHEMA_NAME: ${{ secrets.TEST_SCHEMA_NAME }}
+          TABLE_PREFIX: ${{ secrets.TEST_TABLE_PREFIX }}
+          ANOTHER_CATALOG_NAME: ${{ secrets.TEST_ANOTHER_CATALOG_NAME }}
+      - run: ./gradlew test
+        env:
+          EMBULK_INPUT_DATABRICKS_TEST_CONFIG: "./test-config.yml"
   build:
     name: Build + Publish
     runs-on: ubuntu-latest

--- a/ci/config_template.yml
+++ b/ci/config_template.yml
@@ -1,0 +1,7 @@
+server_hostname: "$SERVER_HOSTNAME"
+http_path: "$HTTP_PATH"
+personal_access_token: "$PERSONAL_ACCESS_TOKEN"
+catalog_name: "$CATALOG_NAME"
+schema_name: "$SCHEMA_NAME"
+table_prefix: "$TABLE_PREFIX"
+another_catalog_name: "$TEST_ANOTHER_CATALOG_NAME"


### PR DESCRIPTION
if you set the described blow variables to the secret of github action, testing on real databricks server is enabled in the github actions workflow.

```
# The catalog_name.schema_name and another_catalog_name.schema_name must be created in advance.
# The another_catalog_name must be different from catalog_name.

TEST_SERVER_HOSTNAME
TEST_HTTP_PATH
TEST_PERSONAL_ACCESS_TOKEN
TEST_CATALOG_NAME
TEST_SCHEMA_NAME
TEST_TABLE_PREFIX
TEST_ANOTHER_CATALOG_NAME
```